### PR TITLE
Fix .sdignore file

### DIFF
--- a/ca.michaelabon.logitech-litra-lights.sdPlugin/.sdignore
+++ b/ca.michaelabon.logitech-litra-lights.sdPlugin/.sdignore
@@ -1,1 +1,1 @@
-logs/
+logs/streamdeck-*.log*


### PR DESCRIPTION
The logs directory needs to exist in order for the plugin to launch. Until I change the code to create the directory if it does not exist, changing the .sdignore file is the quicker fix.