### PR TITLE
Add bump target

### DIFF
--- a/justfile
+++ b/justfile
@@ -130,3 +130,10 @@ logs-streamdeck:
 [windows]
 logs-streamdeck:
   cd "%appdata%\Elgato\StreamDeck\logs\"
+
+
+## VERSIONING
+
+
+bump version:
+  yq --inplace --prettyPrint --output-format json '.Version = "{{ version }}"' {{ PLUGIN }}/manifest.json


### PR DESCRIPTION
I don't have an automated way to install `yq` yet on a dev machine. I'll fix that when I come up against it. It's a common enough tool that I won't be upset in reinstalling it if needed.

Usage:

```
just bump 1.0.5.0
```