### PR TITLE
Add missing dependency “mingw-w64” to macOS install in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -32,8 +32,12 @@ clean:
 ## INSTALL DEV DEPENDENCIES
 
 
-[windows, macos]
+[windows]
 install: _install-submodules _install-go-tools
+
+[macos]
+install: _install-submodules _install-go-tools
+    brew install mingw-w64
 
 [linux] ## WSL support
 install: _install-go-tools


### PR DESCRIPTION
Otherwise, there will be an error message during building:

cgo: C compiler "x86_64-w64-mingw32-gcc" not found: exec: "x86_64-w64-mingw32-gcc": executable file not found in $PATH

Resolves #22 